### PR TITLE
Fix terminal queue bug

### DIFF
--- a/LEDcommander.py
+++ b/LEDcommander.py
@@ -107,6 +107,8 @@ def Run(CommandQueue):
 
     global StopEvent
     global DisplayProcess
+    global CurrentDisplayMode
+    global TerminalQueue
 
     OldCommand = {
             "Action": "showclock",


### PR DESCRIPTION
## Summary
- ensure `Run` uses global `CurrentDisplayMode` and `TerminalQueue`

## Testing
- `python -m py_compile LEDcommander.py`

------
https://chatgpt.com/codex/tasks/task_e_683f4a39bb2c83279000156f69aaa344