### PR TITLE
Add ShowBeatingImageObject helper

### DIFF
--- a/LEDarcade.py
+++ b/LEDarcade.py
@@ -19768,6 +19768,73 @@ def ShowBeatingHeart(h=0,v=0,beats=10,Sleep=0):
     ZoomScreen(ScreenArray,22,32,Sleep)
 
   SpinShrinkTransition(ScreenArray, steps=32, delay = 0.01,start_zoom=100, end_zoom=0)
+
+
+def ShowBeatingImage(ImageLocation, h=0, v=0, beats=10, Sleep=0):
+  """Display an image with a beating (zoom) effect."""
+  image = Image.open(ImageLocation)
+  image = image.convert('RGB')
+  image.thumbnail((HatWidth, HatHeight), Image.ANTIALIAS)
+
+  width, height = image.size
+
+  # Center the image if h and v are both 0
+  if h == 0 and v == 0:
+    h = int((HatWidth  - width)  / 2)
+    v = int((HatHeight - height) / 2)
+
+  ScreenArray = [[(0, 0, 0) for _ in range(HatWidth)] for _ in range(HatHeight)]
+
+  for y in range(height):
+    for x in range(width):
+      r, g, b = image.getpixel((x, y))
+      H = x + h
+      V = y + v
+      if CheckBoundary(H, V) == 0:
+        ScreenArray[V][H] = (r, g, b)
+
+  SpinShrinkTransition(ScreenArray, steps=32, delay=0.01, start_zoom=0, end_zoom=100)
+
+  for i in range(0, beats):
+    time.sleep(0.25)
+    ZoomScreen(ScreenArray, 32, 16, Sleep)
+    time.sleep(0.125)
+    ZoomScreen(ScreenArray, 22, 32, Sleep)
+
+  SpinShrinkTransition(ScreenArray, steps=32, delay=0.01, start_zoom=100, end_zoom=0)
+
+
+def ShowBeatingImageObject(image, h=0, v=0, beats=10, Sleep=0):
+  """Display a beating effect for a preloaded PIL.Image object."""
+  image = image.convert('RGB')
+  image.thumbnail((HatWidth, HatHeight), Image.ANTIALIAS)
+
+  width, height = image.size
+
+  # Center the image if h and v are both 0
+  if h == 0 and v == 0:
+    h = int((HatWidth  - width)  / 2)
+    v = int((HatHeight - height) / 2)
+
+  ScreenArray = [[(0, 0, 0) for _ in range(HatWidth)] for _ in range(HatHeight)]
+
+  for y in range(height):
+    for x in range(width):
+      r, g, b = image.getpixel((x, y))
+      H = x + h
+      V = y + v
+      if CheckBoundary(H, V) == 0:
+        ScreenArray[V][H] = (r, g, b)
+
+  SpinShrinkTransition(ScreenArray, steps=32, delay=0.01, start_zoom=0, end_zoom=100)
+
+  for i in range(0, beats):
+    time.sleep(0.25)
+    ZoomScreen(ScreenArray, 32, 16, Sleep)
+    time.sleep(0.125)
+    ZoomScreen(ScreenArray, 22, 32, Sleep)
+
+  SpinShrinkTransition(ScreenArray, steps=32, delay=0.01, start_zoom=100, end_zoom=0)
  
   
 


### PR DESCRIPTION
## Summary
- extend LEDarcade with `ShowBeatingImageObject` to animate a preloaded image

## Testing
- `python -m py_compile LEDarcade.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f4cb3f7e483278966a3190eac65b3